### PR TITLE
fix: ensure compatibility with native Node ESM system

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@jsq/seq",
   "version": "0.4.1",
   "description": "Lazy sequence operators for JavaScript.",
-  "main": "lib/index.js",
+  "main": "lib/index",
   "module": "lib/index.mjs",
   "types": "lib/index.d.ts",
   "engines": {


### PR DESCRIPTION
Node doesn't honor the `module` key in `package.json`. So the following doesn't work in pure Node, without bundlers/transpilers:
```js
import { filter } from '@jsq/seq'
```
However, this [document](https://github.com/nodejs/node-eps/blob/master/002-es-modules.md#44-shipping-both-esm-and-cjs) suggests omitting file extension in`main`.
I've verified that it works with Node v10.5.0 and the `--experimental-modules` flag.