### PR TITLE
Export helper methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export * from './flatMap';
 export * from './flatten';
 export * from './includes';
 export * from './interleave';
+export * from './isIterable';
+export * from './iteratorFromIterable';
 export * from './map';
 export * from './merge';
 export * from './range';

--- a/src/isIterable.ts
+++ b/src/isIterable.ts
@@ -1,7 +1,17 @@
+/**
+ * Determines if the provided value adheres to the AsyncIterable protocol.
+ *
+ * @param arg Any value
+ */
 export function isAsyncIterable<T>(arg: any): arg is AsyncIterable<T> {
     return Boolean(arg) && typeof arg[Symbol.asyncIterator] === 'function';
 }
 
+/**
+ * Determines if the provided value adheres to Iterable protocol.
+ *
+ * @param arg Any value
+ */
 export function isSyncIterable<T>(arg: any): arg is Iterable<T> {
     return Boolean(arg) && typeof arg[Symbol.iterator] === 'function';
 }

--- a/src/iteratorFromIterable.ts
+++ b/src/iteratorFromIterable.ts
@@ -1,5 +1,14 @@
 import { isAsyncIterable } from './isIterable';
 
+/**
+ * Extracts the underlying synchronous or asynchronous iterator from a
+ * synchronous or asynchronous iterable, respectively.
+ *
+ * If the provided value adheres to both the Iterable and AsyncIterable
+ * protocols, its asynchronous interface will be used.
+ *
+ * @param iterable A synchronous or asynchronous iterable.
+ */
 export function iteratorFromIterable<T>(
     iterable: Iterable<T>|AsyncIterable<T>
 ): Iterator<T>|AsyncIterator<T> {


### PR DESCRIPTION
Resolves #7 

The helper functions are used extensively in other exported functions and their tests, so no new tests need to be added to get them to 100% coverage.